### PR TITLE
Reset isAuthenticating state after login attempt

### DIFF
--- a/src/components/Authentication.jsx
+++ b/src/components/Authentication.jsx
@@ -36,6 +36,8 @@ export default function Authentication(props) {
         } catch (err) {
             console.log(err.message);
             setError(err.message);
+        } finally {
+            setIsAuthenticating(false);
         }
     }
 


### PR DESCRIPTION
Added a finally block to ensure setIsAuthenticating(false) is called after the authentication process, regardless of success or failure. This prevents the loading state from persisting if an error occurs.